### PR TITLE
modify openprompt/data_utils/utils.py，fix bug: in 0_basic.py, inputs.cuda() can only load tensors on gpu:0

### DIFF
--- a/openprompt/data_utils/utils.py
+++ b/openprompt/data_utils/utils.py
@@ -184,7 +184,7 @@ class InputFeatures(dict):
                 setattr(self, key, value.to(device))
         return self
 
-    def cuda(self):
+    def cuda(self, device: str = "cuda:0"):
         r"""mimic the tensor behavior
         """
         return self.to()


### PR DESCRIPTION
in 0_basic.py, prompt_model could be loaded on selected gpu, eg: prompt_model=  prompt_model.cuda(2)
while inputs = inputs.cuda() has no choice but gpu:0, which will lead to the following error:
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:2 and cuda:0! (when checking argument for argument index in method wrapper__index_select)