### PR TITLE
fix InputFeatures .to

### DIFF
--- a/openprompt/data_utils/utils.py
+++ b/openprompt/data_utils/utils.py
@@ -178,11 +178,12 @@ class InputFeatures(dict):
     def to(self, device: str = "cuda:0"):
         r"""move the tensor keys to runtime device, such as gpu:0
         """
-        for key in self.tensorable_keys:
-            value = getattr(self, key)
+        target = copy.deepcopy(self)
+        for key in target.tensorable_keys:
+            value = getattr(target, key)
             if value is not None:
-                setattr(self, key, value.to(device))
-        return self
+                setattr(target, key, value.to(device))
+        return target
 
     def cuda(self, device: str = "cuda:0"):
         r"""mimic the tensor behavior


### PR DESCRIPTION
In the following two scenarios,
```py
for step, inputs in enumerate(cycle(train_dataloader)):
    inputs = inputs.to(device)
    ...
```
or
```py
for step in range(max_steps):
    input = next(cycle(iter(train_dataloader)))
    inputs = inputs.to(device)
    ...
```

raw `InputFeatures.to(...)` causes infinite growth of GPU memory and unavailability of used inputs (e.g. SoftTemplate modifies input_ids of inputs by `batch['input_ids'] = None`)