### PR TITLE
fix typing of max_seq_length from str to int

### DIFF
--- a/openprompt/pipeline_base.py
+++ b/openprompt/pipeline_base.py
@@ -48,7 +48,7 @@ class PromptDataLoader(object):
                  tokenizer: PreTrainedTokenizer = None,
                  tokenizer_wrapper_class = None,
                  verbalizer: Optional[Verbalizer] = None,
-                 max_seq_length: Optional[str] = 512,
+                 max_seq_length: Optional[int] = 512,
                  batch_size: Optional[int] = 1,
                  shuffle: Optional[bool] = False,
                  teacher_forcing: Optional[bool] = False,

--- a/tutorial/7_ernie_paddlepaddle/dataloader.py
+++ b/tutorial/7_ernie_paddlepaddle/dataloader.py
@@ -59,7 +59,7 @@ class ErniePromptDataLoader():
              tokenizer = None,
              tokenizer_wrapper_class = None,
              verbalizer = None,
-             max_seq_length: Optional[str] = 512,
+             max_seq_length: Optional[int] = 512,
              batch_size: Optional[int] = 1,
              shuffle: Optional[bool] = False,
              teacher_forcing: Optional[bool] = False,


### PR DESCRIPTION
Fix the typing error of ``max_seq_length: Optional[str]`` of ``PromptDataLoader`` and ``ErniePromptDataLoader`` both of which should be ``int``.