### PR TITLE
FOR PYTHON 3.11, ON WINDOWS,

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers>=4.19.0
-sentencepiece==0.1.96
+sentencepiece>=0.1.96
 # scikit-learn>=0.24.2
 tqdm>=4.62.2
 tensorboardX

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 requires = """
 transformers>=4.10.0
-sentencepiece==0.1.96
+sentencepiece>=0.1.96
 # scikit-learn>=0.24.2
 tqdm>=4.62.2
 tensorboardX


### PR DESCRIPTION
THERE WAS AN ISSUE WHERE "'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.38.33130\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2"
sentencepiece IN VERSION 0.1.98 FIXED IT.