### PR TITLE
Update sentencepiece requirement version for `arm64` compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers>=4.19.0
-sentencepiece==0.1.96
+sentencepiece>=0.1.96
 # scikit-learn>=0.24.2
 tqdm>=4.62.2
 tensorboardX

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 requires = """
 transformers>=4.10.0
-sentencepiece==0.1.96
+sentencepiece>=0.1.96
 # scikit-learn>=0.24.2
 tqdm>=4.62.2
 tensorboardX


### PR DESCRIPTION
Binaries for `sentencepiece==0.1.96` are not available for arm64 architectures such as Apple M1 chips. Binaries for newer versions of this dependency are, however, available. This PR changes the dependency requirement to allow the installation of newer versions.